### PR TITLE
response method update for CORB protection

### DIFF
--- a/src/RestController.php
+++ b/src/RestController.php
@@ -628,10 +628,18 @@ class RestController extends \CI_Controller
             elseif ($data !== null) {
                 // If the format method exists, call and return the output in that format
                 if (method_exists(Format::class, 'to_'.$this->response->format)) {
-                    // Set the format header
-                    $this->output->set_content_type($this->_supported_formats[$this->response->format], strtolower($this->config->item('charset')));
+                    // CORB protection
+                    // First, get the output content.
                     $output = Format::factory($data)->{'to_'.$this->response->format}();
-
+                    
+                    // Set the format header
+                    // Then, check if the client asked for a callback, and if the output contains this callback :
+                    if (isset($this->_get_args['callback']) && $this->response->format == 'json' && preg_match('/^' . $this->_get_args['callback'] . '/', $output)) {
+                        $this->output->set_content_type($this->_supported_formats['jsonp'], strtolower($this->config->item('charset')));
+                    } else {
+                        $this->output->set_content_type($this->_supported_formats[$this->response->format], strtolower($this->config->item('charset')));
+                    }
+                    
                     // An array must be parsed as a string, so as not to cause an array to string error
                     // Json is the most appropriate form for such a data type
                     if ($this->response->format === 'array') {


### PR DESCRIPTION
CORB protection was added to Chromium based browsers to add further cross-origin resource loads protection.
Details about the protection here : https://chromium.googlesource.com/chromium/src/+/master/services/network/cross_origin_read_blocking_explainer.md
Without this update, some AJAX requests from those browsers fall in the CORB and fail.

The update consists of sending the right Content-Type header for callback encapsuled JSON output : application/javascript instead of application/json